### PR TITLE
Add action to check links

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,53 @@
+name: Check Links
+
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0" # Runs weekly at 00:00 on Sundays
+
+jobs:
+  check_links:
+    name: Check Links
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Ruby 2.6
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+        
+    - name: Run awesome_bot checks
+      run: |
+        gem install awesome_bot
+        awesome_bot README.md --allow-redirect --allow 403
+  
+    - name: Create issue for broken links            
+      if: ${{ failure() }}   
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
+      run: |
+        for entry in $(cat ab-results-README.md-filtered.json | jq -r '.[] | @base64'); do
+          link=$(echo "$entry" | base64 --decode | jq -r '.link')
+          status=$(echo "$entry" | base64 --decode | jq -r '.status')
+          error=$(echo "$entry" | base64 --decode | jq -r '.error')
+
+          if [ -z "$error" ]; then
+            error="$status"
+          fi
+
+          issue_exists=$(gh issue list --state "open" --search "Broken link: $link" | wc -l)
+          
+        if [ "$issue_exists" -eq 0 ]; then
+          # Markdown table with link and error columns
+          body="[awesome_bot](https://github.com/dkhamsing/awesome_bot) found the following broken link:
+          
+          | Link | Status/Error |
+          | ---- | ----- |
+          | $link | $error |"
+          gh issue create --title "Broken link: $link" --body "$body"
+        else
+          echo "Issue already exists for link: $link"
+        fi
+        done


### PR DESCRIPTION
## Add action to check links

- [x] I have read the [contributing guidelines](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/blob/master/CONTRIBUTING.md)
- [x] I agree to the [Code of Conduct](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/blob/master/CODE_OF_CONDUCT.md)
- [x] I have followed the [format](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/blob/master/CONTRIBUTING.md#format) prescribed in the contributing guidelines
- [ ] (OPTIONAL) In your pull request message, add additional context/communication on the visa sponsorship if necessary

### Details
I've added an action that uses [awesome_bot](https://github.com/dkhamsing/awesome_bot) to validate the links of each company website. The action will automatically run each week, during a PR, and can be triggered manually.

For each broken link, a new Issue will be created (duplicate issues will not be created if there is already one open) For example:
![image](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/assets/45926200/4243a717-eab3-406d-97e3-8824e9b33d2a)
![image](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/assets/45926200/6eaebb32-106f-4c1c-8f99-c63e4aea11a8)
![image](https://github.com/geshan/au-companies-providing-work-visa-sponsorship/assets/45926200/ed3d4e6f-33d6-4375-9068-deaa696705a7)